### PR TITLE
feat: Implement favorite gyms with location tracking

### DIFF
--- a/MatMindset/Core/Home/HomeView.swift
+++ b/MatMindset/Core/Home/HomeView.swift
@@ -98,13 +98,7 @@ struct HomeView: View {
                 // Request location access and optionally set the gym location if needed
                 locationManager.requestAuthorization()
                 locationManager.startUpdatingLocation() // ✅ THIS IS CRITICAL
-                
-                
-                // Example gym, should be dynamic
-                let storeLatitude = 32.6226760
-                let storeLongitude = -116.9999206
-                let gym = CLLocationCoordinate2D(latitude: storeLatitude, longitude: storeLongitude)
-                locationManager.setGymLocation(latitude: gym.latitude, longitude: gym.longitude)
+                // Removed hardcoded gym location setup
                 
                 if isCheckedIn {
                     DispatchQueue.main.asyncAfter(deadline: .now() + 60 * 60) { // 1 hour later

--- a/MatMindset/Core/Profile/ProfileView.swift
+++ b/MatMindset/Core/Profile/ProfileView.swift
@@ -10,10 +10,20 @@ import SwiftUI
 struct ProfileView: View {
     @AppStorage("userName") private var userName: String = ""
     @AppStorage("userRank") private var userRank: String = "White"
-    @AppStorage("userGym") private var userGym: String = ""
+    // @AppStorage("userGym") private var userGym: String = "" // Removed
     @AppStorage("monthlyGoal") private var monthlyGoal: Int = 12
 
+    @State private var showingGymPicker = false // Added for sheet presentation
+    @AppStorage("favoriteGyms") private var favoriteGymsData: Data = Data() // Added for gym data
+
     let bjjBelts = ["White", "Blue", "Purple", "Brown", "Black"]
+
+    private var favoriteGyms: [GymLocation] { // Added computed property
+        if let decoded = try? JSONDecoder().decode([GymLocation].self, from: favoriteGymsData) {
+            return decoded
+        }
+        return []
+    }
 
     var body: some View {
         NavigationStack {
@@ -35,13 +45,31 @@ struct ProfileView: View {
                             Text(belt)
                         }
                     }
-
-                    TextField("Gym", text: $userGym)
+                    // TextField("Gym", text: $userGym) // Removed
                 }
 
                 Section(header: Text("Training Goal")) {
                     Stepper(value: $monthlyGoal, in: 1...30, step: 1) {
                         Text("Monthly Goal: \(monthlyGoal) sessions")
+                    }
+                }
+
+                Section(header: Text("Favorite Gyms")) { // Added Favorite Gyms section
+                    if favoriteGyms.isEmpty {
+                        Text("No favorite gyms yet. Add one!")
+                    } else {
+                        ForEach(favoriteGyms) { gym in
+                            HStack {
+                                Text(gym.name)
+                                Spacer()
+                                Text("Lat: \(gym.latitude, specifier: "%.2f"), Lon: \(gym.longitude, specifier: "%.2f")")
+                                    .font(.caption)
+                                    .foregroundColor(.gray)
+                            }
+                        }
+                    }
+                    Button("Manage Favorite Gyms") {
+                        showingGymPicker = true
                     }
                 }
             }
@@ -51,6 +79,9 @@ struct ProfileView: View {
                 }
             }
             .navigationTitle("Profile")
+            .sheet(isPresented: $showingGymPicker) { // Added sheet modifier
+                SimpleGymPickerView(selectedGym: .constant(nil))
+            }
         }
     }
 }


### PR DESCRIPTION
This commit introduces the ability for you to manage a list of favorite gyms and for the app to track proximity to these locations.

Key changes include:

-   **Gym Model:** `GymLocation` struct enhanced with `id`, `latitude`, and `longitude`.
-   **Favoriting UI:**
    -   `SimpleGymPickerView` updated to manage `GymLocation` objects (including manual coordinate input) and save/load them from `@AppStorage`.
    -   `ProfileView` now displays a list of favorite gyms with their coordinates and provides access to `SimpleGymPickerView` for management. The old single-gym text field has been removed.
-   **Location Tracking:**
    -   `LocationManager` refactored to load favorite gyms from `@AppStorage`.
    -   Proximity checks (`isAtGym`) are now performed against the list of all favorited gyms.
    -   Removed hardcoded gym location from `HomeView`; it now relies on the updated `LocationManager`.
-   **Data Storage:** Favorite gyms are stored as an array of `Codable` `GymLocation` objects in `@AppStorage`.

You can now add gyms with their specific locations, mark them as favorites, see them in your profile, and the app will use these locations to determine if you are at one of your favorite gyms for features like check-in.